### PR TITLE
Pass `:broken_record` context to validation call.

### DIFF
--- a/lib/broken_record/job.rb
+++ b/lib/broken_record/job.rb
@@ -17,7 +17,7 @@ module BrokenRecord
           record_ids.each_slice(batch_size) do |id_batch|
             model_scope.where("#{klass.table_name}.#{primary_key}" => id_batch).each do |r|
               begin
-                if !r.valid?(:broken_record)
+                if !r.valid?([:update, :broken_record])
                   message = "    Invalid record in #{klass} id=#{r.id}."
                   r.errors.each { |attr,msg| message <<  "\n        #{attr} - #{msg}" } unless compact_output
                   result.add_error message

--- a/lib/broken_record/job.rb
+++ b/lib/broken_record/job.rb
@@ -17,7 +17,7 @@ module BrokenRecord
           record_ids.each_slice(batch_size) do |id_batch|
             model_scope.where("#{klass.table_name}.#{primary_key}" => id_batch).each do |r|
               begin
-                if !r.valid?
+                if !r.valid?(:broken_record)
                   message = "    Invalid record in #{klass} id=#{r.id}."
                   r.errors.each { |attr,msg| message <<  "\n        #{attr} - #{msg}" } unless compact_output
                   result.add_error message


### PR DESCRIPTION
The `valid?` method takes an optional context argument. Validations
themselves can take an `on:` kwarg; if they do, they will only run
when the matching symbol is passed to the `valid?` method. Validations
without an `on:` kwarg will run every time.

By passing a `:broken_record` context to `valid?`, we can scope
expensive sanity-check validations to only run during the broken record
pass, and not during normal app operation. After this is deployed, all
that's needed to scope that is to add `on: :broken_record` to that
validation.