### PR TITLE
fix Exception rescue

### DIFF
--- a/lib/broken_record/job.rb
+++ b/lib/broken_record/job.rb
@@ -22,12 +22,12 @@ module BrokenRecord
                   r.errors.each { |attr,msg| message <<  "\n        #{attr} - #{msg}" } unless compact_output
                   result.add_error message
                 end
-              rescue Exception => e
+              rescue => e
                 result.add_error serialize_exception("    Exception for record in #{klass} id=#{r.id} ", e, compact_output)
               end
             end
           end
-        rescue Exception => e
+        rescue => e
           result.add_error serialize_exception("    Exception while trying to load models for #{klass}.", e, compact_output)
         end
 

--- a/lib/broken_record/version.rb
+++ b/lib/broken_record/version.rb
@@ -1,3 +1,3 @@
 module BrokenRecord
-  VERSION = '0.2.1.gusto'
+  VERSION = '0.2.2.gusto'
 end


### PR DESCRIPTION
I am investigating the PayrollValidation job on Jenkins, and in some cases, the `Exception for record in...` message is strange as the validation for the record passes. 

I would expect this PR to makes things better and this is a better practice so nothing to lose - see http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby for more information about this change.

🌴 