### PR TITLE
more output for exceptions

### DIFF
--- a/lib/broken_record/job.rb
+++ b/lib/broken_record/job.rb
@@ -23,7 +23,8 @@ module BrokenRecord
                   result.add_error message
                 end
               rescue => e
-                result.add_error serialize_exception("    Exception for record in #{klass} id=#{r.id} ", e, compact_output)
+                error_message = "    Exception for record in #{klass} id=#{r.id} - #{e.class} #{e.message}"
+                result.add_error serialize_exception(error_message, e, compact_output)
               end
             end
           end

--- a/lib/broken_record/version.rb
+++ b/lib/broken_record/version.rb
@@ -1,3 +1,3 @@
 module BrokenRecord
-  VERSION = '0.2.2.gusto'
+  VERSION = '0.2.3.gusto'
 end


### PR DESCRIPTION
A lot of exceptions don't happen in the console when we check these records.
We need more information why these are failing.

This will add outputs like `"NoMethodError - undefined method `employee' for nil:NilClass"` :)