### PR TITLE
Allow SlackAggregator to optionally add snippet of errors

### DIFF
--- a/broken_record.gemspec
+++ b/broken_record.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rake', '>= 10.1.10'
   spec.add_runtime_dependency 'parallel', '>= 1.2.3'
-  spec.add_runtime_dependency 'colorize', '>= 0.5.8'
+  spec.add_runtime_dependency 'colorize', '>= 0.8.1'
   spec.add_runtime_dependency 'dogapi', '~> 1'
 end

--- a/lib/broken_record/config.rb
+++ b/lib/broken_record/config.rb
@@ -20,7 +20,6 @@ module BrokenRecord
     self.job_scheduler_options = {}
     self.slack_options = {}
     self.datadog_api_key = ENV['DATADOG_API_KEY']
-    # TODO: Add option to slack_add_snippet
 
     def before_scan(&block)
       self.before_scan_callbacks << block

--- a/lib/broken_record/config.rb
+++ b/lib/broken_record/config.rb
@@ -20,6 +20,7 @@ module BrokenRecord
     self.job_scheduler_options = {}
     self.slack_options = {}
     self.datadog_api_key = ENV['DATADOG_API_KEY']
+    # TODO: Add option to slack_add_snippet
 
     def before_scan(&block)
       self.before_scan_callbacks << block

--- a/lib/broken_record/result_aggregator.rb
+++ b/lib/broken_record/result_aggregator.rb
@@ -28,6 +28,14 @@ module BrokenRecord
 
     private
 
+    def all_classes
+      @aggregated_results.keys
+    end
+
+    def all_results
+      @aggregated_results.values.flatten
+    end
+
     def all_errors(klass)
        @aggregated_results[klass].flat_map(&:errors)
     end

--- a/lib/broken_record/slack_aggregator.rb
+++ b/lib/broken_record/slack_aggregator.rb
@@ -7,7 +7,13 @@ module BrokenRecord
         icon_emoji: success? ? ':white_check_mark:' : ':x:',
         username: "#{app_name} ValidationMaster"
       })
+      send_summary
+      send_snippet
+    end
 
+    private
+
+    def send_summary
       if success?
         notifier.send!("\nAll models validated successfully.")
       else
@@ -15,5 +21,11 @@ module BrokenRecord
       end
     end
 
+    def send_snippet
+      # For all validated classes, get all-errors on each class, and print all_errors
+      require 'pry'; binding.pry
+      @aggregated_results
+      puts 'sending snippet'
+    end
   end
 end

--- a/lib/broken_record/slack_notifier.rb
+++ b/lib/broken_record/slack_notifier.rb
@@ -1,26 +1,27 @@
 require 'net/http'
 module BrokenRecord
   class SlackNotifier
-    def initialize(options)
-      @options = BrokenRecord::Config.slack_options.merge(options)
+    def initialize(initial_options)
+      @options = default_options
+      @options = @options.merge(initial_options)
+      @options = @options.merge(BrokenRecord::Config.slack_options)
     end
 
     def send!(message)
+      return unless @options[:summary]
       if defined?(Rails) && Rails.env.development?
         puts message
       else
-        slack_params = options.merge(text: message)
+        slack_params = @options.merge(text: message)
         uri = URI('https://slack.com/api/chat.postMessage')
         uri.query = URI.encode_www_form(slack_params)
         Net::HTTP.get(uri)
       end
     end
 
-    private
+    def
 
-    def options
-      default_options.merge(@options)
-    end
+    private
 
     def default_options
       {
@@ -31,6 +32,7 @@ module BrokenRecord
         pretty: '1',
         username: 'ValidationMaster',
         icon_emoji: ':llama:',
+        summary: true
       }
     end
 

--- a/lib/broken_record/slack_notifier.rb
+++ b/lib/broken_record/slack_notifier.rb
@@ -19,7 +19,31 @@ module BrokenRecord
       end
     end
 
-    def
+    def send_snippet!(snippet_body, snippet_title)
+      return unless @options[:snippet]
+      if defined?(Rails) && Rails.env.development?
+        puts message
+      else
+        slack_params = @options.merge({
+          title: snippet_title,
+          initial_comment: ':heavy_exclamation_mark: @benefitsvm: The validation job failed!',
+          icon_emoji: ':x:',
+          channels: @options[:channel]
+        })
+
+        # Upload file to slack via multipart/form-data
+        snippet_file = Tempfile.new
+        begin
+          snippet_file.write(snippet_body)
+          snippet_file.rewind
+          encoded_params = slack_params.map{ |key, value| "-F \"#{key}=#{value}\"" }.join(' ')
+          `curl -F file=@#{snippet_file.path} #{encoded_params} https://slack.com/api/files.upload`
+        ensure
+          snippet_file.close
+          snippet_file.unlink
+        end
+      end
+    end
 
     private
 
@@ -32,7 +56,8 @@ module BrokenRecord
         pretty: '1',
         username: 'ValidationMaster',
         icon_emoji: ':llama:',
-        summary: true
+        summary: true,
+        snippet: false
       }
     end
 

--- a/lib/broken_record/version.rb
+++ b/lib/broken_record/version.rb
@@ -1,3 +1,3 @@
 module BrokenRecord
-  VERSION = '0.2.10.gusto'
+  VERSION = '0.3.10.gusto'
 end


### PR DESCRIPTION
Hey @emilyefield.  Here are some of the changes we made today.  Let's find another time to look at this next week.

Next steps for broken record:
- See how slack notifier can get access to records
  - Should be straightforward -- will probably just need to change the method signature for print summary to also include non-aggregated results
- Get access to out of band validations, Validation::OutOfBandValidation
- What do those results look like
- How to send snippet, what snippet looks like -> possibly only failures if any exist