### PR TITLE
Show number of models with errors in addition to total error count

### DIFF
--- a/lib/broken_record/aggregators/console_aggregator.rb
+++ b/lib/broken_record/aggregators/console_aggregator.rb
@@ -3,38 +3,14 @@ module BrokenRecord
     class ConsoleAggregator < ResultAggregator
       def report_results(klass, logger: $stdout)
         super(klass)
-
-        default_result_count = BrokenRecord::Config.default_result_count
-
         class_errors = errors_for(klass)
-        error_ids_for = error_ids_for(klass)
+        invalid_model_ids = error_ids_for(klass).uniq
         duration = duration(klass)
 
-        formatted_errors = class_errors.map do |reportable_error|
-          id = reportable_error.id
-          message = "    Invalid record in #{klass.name} id=#{id}.\n        "
-          message << reportable_error.message
-          message.red
-        end
-
-        formatted_errors = formatted_errors[0...default_result_count].join("\n")
-
         logger.print "Running validations for #{klass}... ".ljust(70)
-        if class_errors.empty?
-          logger.print '[PASS]'.green
-        else
-          logger.print '[FAIL]'.red
-        end
-        logger.print "  (#{duration}s)\n"
-
-        error_count = class_errors.length
-        displayed_validation_errors_count = [error_count, default_result_count].min
-        if class_errors.any?
-          logger.puts "#{class_errors.length} errors were found while running validations for #{klass}\n"
-          logger.puts "Invalid ids: #{error_ids_for.inspect}"
-          logger.puts "Validation errors on first #{displayed_validation_errors_count} invalid models"
-          logger.puts formatted_errors
-        end
+        success = class_errors.empty?
+        report_result_header(logger, success, duration)
+        report_class_errors(logger, klass, class_errors, invalid_model_ids, duration) if class_errors.any?
       end
 
       def report_final_results(logger: $stdout)
@@ -43,6 +19,43 @@ module BrokenRecord
         else
           logger.puts "\n#{total_error_count} errors were found while running validations.".red
         end
+      end
+
+      private
+
+      def report_result_header(logger, success, duration)
+        if success
+          logger.print '[PASS]'.green
+        else
+          logger.print '[FAIL]'.red
+        end
+
+        report_duration(logger, duration)
+      end
+
+      def report_class_errors(logger, klass, class_errors, invalid_model_ids, duration)
+        default_result_count = BrokenRecord::Config.default_result_count
+
+        displayed_validation_errors_count = [class_errors.count, default_result_count].min
+
+        logger.puts "#{class_errors.length} errors were found on #{invalid_model_ids.count} models while running validations for #{klass}\n"
+        logger.puts "Invalid ids: #{invalid_model_ids.inspect}"
+        logger.puts "First #{displayed_validation_errors_count} errors"
+
+        formatted_errors = class_errors.map do |reportable_error|
+          id = reportable_error.id
+          message = "    Invalid record in #{klass.name} id=#{id}.\n        "
+          message << reportable_error.message
+          message.red
+        end
+
+        formatted_errors = formatted_errors[0...displayed_validation_errors_count].join("\n")
+
+        logger.puts formatted_errors
+      end
+
+      def report_duration(logger, duration)
+        logger.print "  (#{duration}s)\n"
       end
     end
   end

--- a/lib/broken_record/aggregators/slack_aggregator.rb
+++ b/lib/broken_record/aggregators/slack_aggregator.rb
@@ -30,7 +30,7 @@ module BrokenRecord
         all_results.each{ |result| console_aggregator.add_result(result) }
         # Store the output of the console aggregator into a StringIO object
         validation_logger = StringIO.new
-        snippet = all_classes.each { |klass| console_aggregator.report_results(klass, logger: validation_logger) }
+        all_classes.each { |klass| console_aggregator.report_results(klass, logger: validation_logger) }
 
         if !success?
           notifier.send_snippet!(validation_logger.string.uncolorize, 'Model Validation Failures')

--- a/lib/broken_record/version.rb
+++ b/lib/broken_record/version.rb
@@ -1,3 +1,3 @@
 module BrokenRecord
-  VERSION = '0.5.2.gusto'
+  VERSION = '0.6.2.gusto'
 end

--- a/spec/lib/broken_record/aggregators/slack_aggregator_spec.rb
+++ b/spec/lib/broken_record/aggregators/slack_aggregator_spec.rb
@@ -18,32 +18,16 @@ module BrokenRecord::Aggregators
       context 'errors' do
         include_context 'aggregator setup'
         it 'outputs the correct validation data to the snippet' do
-          expected_snippet = <<-eos
-Running validations for Object...                                     [FAIL]  (25.0s)
-1 errors were found while running validations for Object
-Invalid ids: [1]
-Validation errors on first 1 invalid models
-    Invalid record in Object id=1.
-        invalid Object model 1
-Running validations for Array...                                      [FAIL]  (11.0s)
-1 errors were found while running validations for Array
-Invalid ids: [2]
-Validation errors on first 1 invalid models
-    Invalid record in Array id=2.
-        invalid Array model 2
-Running validations for String...                                     [FAIL]  (0.234s)
-3 errors were found while running validations for String
-Invalid ids: [3, 4, 5]
-Validation errors on first 3 invalid models
-    Invalid record in String id=3.
-        invalid String model 3
-    Invalid record in String id=4.
-        invalid String model 4
-    Invalid record in String id=5.
-        invalid String model 5
-eos
+          expect_any_instance_of(BrokenRecord::Aggregators::ConsoleAggregator)
+            .to receive(:report_results).with(String, logger: an_instance_of(StringIO))
+          expect_any_instance_of(BrokenRecord::Aggregators::ConsoleAggregator)
+            .to receive(:report_results).with(Object, logger: an_instance_of(StringIO))
+          expect_any_instance_of(BrokenRecord::Aggregators::ConsoleAggregator)
+            .to receive(:report_results).with(Array, logger: an_instance_of(StringIO))
+
+          expect_any_instance_of(StringIO).to receive_message_chain(:string, :uncolorize).and_return('stubbed failures')
           expect(slack_notifier).to receive(:send!).with("\n5 errors were found while running validations.")
-          expect(slack_notifier).to receive(:send_snippet!).with(expected_snippet, 'Model Validation Failures')
+          expect(slack_notifier).to receive(:send_snippet!).with('stubbed failures', 'Model Validation Failures')
           subject
         end
       end


### PR DESCRIPTION
This is a small little improvement I want to do for the console aggregator which we rely on heavily in #eng-benefits.  Before I was showing the ids for each error, rather than the erroneous model ids.  For example, below is what this might look like if we have 90 errors on about 34 models.

```
Validating subscriptions
Running validations for Validation::SubscriptionValidation...         [FAIL]  (2844.049s)
90 errors were found while running validations for Validation::SubscriptionValidation
Invalid ids: [37530, 37530, 37814, 37814, 37817, 37817, 37817, 37820, 37820, 37820, 37831, 37831, 37831, 37834, 37834, 37834, 37860, 37860, 37860, 38004, 38004, 38052, 38052, 38052, 39142, 39142, 39142, 50331, 50331, 50331, 50472, 50472, 50472, 50839, 50839, 52385, 52385, 52385, 53870, 53870, 53870, 54674, 54674, 54674, 55102, 55102, 55102, 55106, 55106, 55106, 55267, 55267, 55267, 55513, 55559, 55559, 55559, 56438, 56438, 56438, 56642, 56642, 56642, 57579, 57579, 57579, 58086, 58086, 58086, 58091, 58091, 58091, 58294, 58294, 61804, 61804, 61804, 66170, 90501, 90501, 90501, 92201, 99534, 99534, 99534, 111333, 111333, 111333, 126471, 126471]
Validation errors on first 90 invalid models
```

I wanted this instead to be:
```
Validating subscriptions
Running validations for Validation::SubscriptionValidation...         [FAIL]  (2844.049s)
90 errors on 34 models were found while running validations for Validation::SubscriptionValidation
Invalid ids: [37530, 37814, 37817, 37820, 37831, 37834, 37860, 38004, 38052, 39142, 50331, 50472, 50839, 52385, 53870, 54674, 55102, 55106, 55267, 55513, 55559, 56438, 56642, 57579, 58086, 58091, 58294, 61804, 66170, 90501, 92201, 99534, 111333, 126471]
First 90 errors
```