### PR TITLE
Skip all abstract classes so we don't have to manually add them to the skip list as new ones are created

### DIFF
--- a/lib/broken_record/services/class_finder.rb
+++ b/lib/broken_record/services/class_finder.rb
@@ -14,15 +14,24 @@ module BrokenRecord
       end
 
       private
+
       def load_all_active_record_classes
         Rails.application.eager_load!
         objects = Set.new
-        # Classes to skip may either be constants or strings.  Convert all to strings for easier lookup
+        # Classes to skip may either be constants or strings.
+        # Convert all to strings for easier lookup
         classes_to_skip = BrokenRecord::Config.classes_to_skip.map(&:to_s)
+
         ActiveRecord::Base.descendants.each do |klass|
-          # Use base_class so we don't try to validate abstract classes and so we don't validate
-          # STI classes multiple times.  See active_record/inheritance.rb for more details.
-          objects.add klass.base_class unless classes_to_skip.include?(klass.to_s)
+          next if classes_to_skip.include?(klass.to_s)
+
+          # Skip any abstract classes, since they do not have
+          # any models to validate directly.
+          next if klass.try(:abstract_class?)
+
+          # Use base_class so we don't validate STI classes multiple times.
+          # See active_record/inheritance.rb for more details.
+          objects.add klass.base_class
         end
 
         prioritized_classes = BrokenRecord::Config.prioritized_models

--- a/lib/broken_record/services/class_finder.rb
+++ b/lib/broken_record/services/class_finder.rb
@@ -25,9 +25,9 @@ module BrokenRecord
         ActiveRecord::Base.descendants.each do |klass|
           next if classes_to_skip.include?(klass.to_s)
 
-          # Skip any abstract classes, since they do not have
-          # any models to validate directly.
-          next if klass.try(:abstract_class?)
+          # Skip abstract classes since they do not have
+          # any records we can validate.
+          next if klass.abstract_class?
 
           # Use base_class so we don't validate STI classes multiple times.
           # See active_record/inheritance.rb for more details.

--- a/lib/broken_record/version.rb
+++ b/lib/broken_record/version.rb
@@ -1,3 +1,3 @@
 module BrokenRecord
-  VERSION = '0.6.2.gusto'
+  VERSION = '0.6.3.gusto'
 end


### PR DESCRIPTION
When upgrading Doorkeeper, the BrokenRecord spec failed because Doorkeeper added an abstract ActiveRecord class called 'Doorkeeper::BaseRecord'. In order to complete the upgrade, I had to manually add the class to the list of models to skip validation.

Going forward, abstract models should not need to be manually specified since we will never be able to validate them. This change will mean we can make fewer changes when upgrading external gems that add abstract classes.