### PR TITLE
⬆️ Bugsnag

### DIFF
--- a/broken_record.gemspec
+++ b/broken_record.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'parallel', '>= 1.2.3'
   spec.add_runtime_dependency 'colorize', '>= 0.8.1'
   spec.add_runtime_dependency 'dogapi', '~> 1'
-  spec.add_runtime_dependency 'bugsnag', '~> 5.0'
+  spec.add_runtime_dependency 'bugsnag', '~> 6.6', '>= 6.6.4'
 end

--- a/lib/broken_record/aggregators/bugsnag_aggregator.rb
+++ b/lib/broken_record/aggregators/bugsnag_aggregator.rb
@@ -50,7 +50,12 @@ module BrokenRecord
       private
 
       def notify(exception, options)
-        Bugsnag.notify(exception, options)
+        Bugsnag.notify(exception) do |report|
+          report.context = options[:context]
+          report.grouping_hash = options[:grouping_hash]
+
+          report.add_tab(:custom, options.slice(:ids, :error_count, :message, :class))
+        end
       end
 
       def notify_deploy


### PR DESCRIPTION
## Description
Pulling from the upgrade guide ([link](https://github.com/bugsnag/bugsnag-ruby/blob/e7ba1d43a283f71c7c0e224b1a02383de5649763/UPGRADING.md)):

## 5.x to 6.x

_Our Ruby library has gone through some major improvements and there are a few
changes required to use the new integrations_

#### Capistrano and deploys
:white_check_mark: No work needed here.

Support for notifying Bugsnag of deployments has been separated into a separate
gem named `bugsnag-capistrano`. See the [integration
guide](https://docs.bugsnag.com/platforms/ruby/capistrano) for more information.


#### Configuration
:white_check_mark: No work needed here.

* `Configuration.use_ssl` has been removed. Include the preferred protocol in `Configuration.endpoint` instead.
  ```diff
    Bugsnag.configure do |config|
  -   config.use_ssl = true
  -   config.endpoint = 'myserver.example.com'
  +   config.endpoint = 'https://myserver.example.com'
    end
  ```
* `Configuration.ignore_classes` now no longer accepts strings. Use classes directly instead.
* `Configuration.delay_with_resque` has been removed
* `Configuration.vendor_paths` has been removed
* `Configuration.params_filters` has been renamed to `Configuration.meta_data_filters` to be clearer


#### Notifying


* `notify` now only supports block syntax. Replace usage of the overrides hash with a block

  ```diff
  - Bugsnag.notify(e, {severity: 'info'})
  + Bugsnag.notify(e) do |report|
  +   report.severity = 'info'
  + end
  ```
  - :white_check_mark: lib/broken_record/aggregators/bugsnag_aggregator.rb


* `Bugsnag.notify_or_ignore` and `Bugsnag.auto_notify` have been removed removed. Call `notify` directly instead.
* `after_notify_callbacks` has been removed
* `Bugsnag::Notification` has been renamed to `Bugsnag::Report`


#### Logging
:white_check_mark: No work needed here.
* `config.debug` boolean has been removed. Set the logger level directly

  ```diff
  + require 'logger'

    Bugsnag.configure do |config|
      # .. set API key and other properties
  -   config.debug = true
  +   config.logger.level = Logger::DEBUG
    end
  ```