### PR TITLE
🐛 Replace `Bugsnag::Deploy` with `Bugsnag::Capistrano::Deploy`

### DIFF
--- a/broken_record.gemspec
+++ b/broken_record.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'colorize', '>= 0.8.1'
   spec.add_runtime_dependency 'dogapi', '~> 1'
   spec.add_runtime_dependency 'bugsnag', '~> 6.6', '>= 6.6.4'
+  spec.add_runtime_dependency 'bugsnag-capistrano', '~> 1.1', '>= 1.1.1'
 end

--- a/lib/broken_record/version.rb
+++ b/lib/broken_record/version.rb
@@ -1,3 +1,3 @@
 module BrokenRecord
-  VERSION = '0.6.4.gusto'
+  VERSION = '1.0.0.gusto'
 end

--- a/spec/lib/broken_record/aggregators/bugsnag_aggregator_spec.rb
+++ b/spec/lib/broken_record/aggregators/bugsnag_aggregator_spec.rb
@@ -3,7 +3,30 @@ module BrokenRecord::Aggregators
     let(:bugsnag_aggregator) { BugsnagAggregator.new }
     let(:logger) { StringIO.new }
 
+    # Shared context variables
     let(:aggregator) { bugsnag_aggregator }
+
+    describe '#report_job_start' do
+      include_context 'aggregator setup'
+      subject(:report_job_start) { bugsnag_aggregator.report_job_start }
+
+      context 'when bugsnag_api_key is not set' do
+        it 'raises an error' do
+          expect { report_job_start }.to raise_error BugsnagAggregator::BUGSNAG_API_KEY_ERROR
+        end
+      end
+
+      context 'when bugsnag_api_key is set' do
+        before { allow(BrokenRecord::Config).to receive(:bugsnag_api_key).and_return('api_key') }
+
+        it 'configures and notifies bugsnag' do
+
+          expect(Bugsnag).to receive(:configure)
+          expect(Bugsnag::Capistrano::Deploy).to receive(:notify)
+          report_job_start
+        end
+      end
+    end
 
     describe '#report_results' do
       include_context 'aggregator setup'


### PR DESCRIPTION
## Context
With the major version upgrade of `Bugsnag`, the deploy notifications were pulled out into `bugsnag-capistrano` (which does not actually require Capistrano for deploy notifications). 

## Changes
- Added `bugsnag-capistrano` gem
- Swapped out `Bugsnag::Deploy` for `Bugsnag::Capistrano::Deploy`
- Added a test to prevent regressions (and show the failing error to start)