### PR TITLE
Allow aggregators to specify how to exit

### DIFF
--- a/lib/broken_record/aggregators/bugsnag_aggregator.rb
+++ b/lib/broken_record/aggregators/bugsnag_aggregator.rb
@@ -49,6 +49,10 @@ module BrokenRecord
         end
       end
 
+      def exit_program
+        exit(0)
+      end
+
       private
 
       def notify(exception, options)

--- a/lib/broken_record/aggregators/multi_aggregator.rb
+++ b/lib/broken_record/aggregators/multi_aggregator.rb
@@ -16,6 +16,16 @@ module BrokenRecord
         @aggregators.all?(&:success?)
       end
 
+      def exit_program
+        bugsnag_aggregator = @aggregators.find { |a| a.is_a?(BugsnagAggregator) }
+
+        if bugsnag_aggregator
+          bugsnag_aggregator.exit_program
+        else
+          exit(success? ? 0 : 1)
+        end
+      end
+
       def method_missing(method, *args, &block)
         @aggregators.map do |a|
           a.send(method, *args, &block)

--- a/lib/broken_record/aggregators/result_aggregator.rb
+++ b/lib/broken_record/aggregators/result_aggregator.rb
@@ -34,6 +34,10 @@ module BrokenRecord
         results_for_class(klass).errors.count
       end
 
+      def exit_program
+        exit(success? ? 0 : 1)
+      end
+
       private
 
       def total_error_count

--- a/lib/broken_record/tasks.rb
+++ b/lib/broken_record/tasks.rb
@@ -9,6 +9,6 @@ namespace :broken_record do
     aggregator = scanner.run(class_names)
     aggregator.report_final_results
 
-    exit 1 unless aggregator.success?
+    aggregator.exit_program
   end
 end


### PR DESCRIPTION
This will allow us to run validations in Jenkins and exit non-zero if the infrastructure fails. Given we are reporting all these responses to Bugsnag, we don't need to rely on PayrollValidation alerting us when the jenkins job fails