### PR TITLE
Reconnect to Database On Each Job Run using Parallel Gem

### DIFF
--- a/lib/broken_record/schedulers/external_job_scheduler.rb
+++ b/lib/broken_record/schedulers/external_job_scheduler.rb
@@ -15,6 +15,7 @@ module BrokenRecord
 
         # Don't run in parallel, just utilize the callback functionality of the parallel gem
         Parallel.each(jobs, { finish: finish_callback, in_processes: 0 }) do |job|
+          ActiveRecord::Base.connection.reconnect!
           job.perform
         end
       end

--- a/lib/broken_record/version.rb
+++ b/lib/broken_record/version.rb
@@ -1,3 +1,3 @@
 module BrokenRecord
-  VERSION = '1.0.0.gusto'
+  VERSION = '1.0.1.gusto'
 end


### PR DESCRIPTION
Recently our HIValidations job has been failing with connection issues:
https://jenkins.zp.int/view/Validations/job/HIValidation/2349/console
<img width="1075" alt="Screen Shot 2019-07-01 at 2 17 19 PM" src="https://user-images.githubusercontent.com/42558742/60467255-f5442280-9c0a-11e9-9271-64b3e65524f6.png">

Through some investigation, it looks like the Parallel gem has an interesting bug with Postgresql where it will disconnect from the database after each job run.
http://ruby.zigzo.com/2012/01/29/the-parallel-gem-and-postgresql-oh-and-rails/

Because we now will run multiple batches of jobs with the ExternalJobScheduler with the updates to how we send validation job errors, we will need to reconnect to the database before each job run in the ExternalJobScheduler too.

Note: I bumped the ruby version but have not published the gem yet. Will publish once the PR is merged