### PR TITLE
Update BK pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,8 +9,8 @@ steps:
 
   - name: ':rocket: Publish to Gem Server'
     command:
-    - 'docker build -t gusto-broken-record:$BUILDKITE_BUILD_ID .'
-    - 'docker run -t gusto-broken-record:$BUILDKITE_BUILD_ID sh -c "gem build broken_record.gemspec && gem push --config-file .gem/credentials --key gemstash --host https://gemstash.zp-int.com/private *.gem"'
+      - 'docker build -t gusto-broken-record:$BUILDKITE_BUILD_ID .'
+      - 'docker run -t gusto-broken-record:$BUILDKITE_BUILD_ID sh -c "gem build broken_record.gemspec && gem push --config-file .gem/credentials --key gemstash --host https://gemstash.zp-int.com/private *.gem"'
     branches: master
     agents:
       queue: gemstash-publish

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,16 @@
 steps:
   - name: ':rspec:'
-    command: 'rspec'
-    env:
-      BUILDKITE_DOCKER: 'true'
+    command:
+      - 'docker build -t gusto-broken-record:$BUILDKITE_BUILD_ID .'
+      - 'docker run -t gusto-broken-record:$BUILDKITE_BUILD_ID rspec'
+
+  - block: ':rocket: Publish to Gem Server'
+    branches: master
+
+  - name: ':rocket: Publish to Gem Server'
+    command:
+    - 'docker build -t gusto-broken-record:$BUILDKITE_BUILD_ID .'
+    - 'docker run -t gusto-broken-record:$BUILDKITE_BUILD_ID sh -c "gem build broken_record.gemspec && gem push --config-file .gem/credentials --key gemstash --host https://gemstash.zp-int.com/private *.gem"'
+    branches: master
+    agents:
+      queue: gemstash-publish

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,5 @@
+steps:
+  - name: ':rspec:'
+    command: 'rspec'
+    env:
+      BUILDKITE_DOCKER: 'true'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,12 +5,12 @@ steps:
       - 'docker run -t gusto-broken-record:$BUILDKITE_BUILD_ID rspec'
 
   - block: ':rocket: Publish to Gem Server'
-    branches: 'master nw-ci-pipeline'
+    branches: master
 
   - name: ':rocket: Publish to Gem Server'
     command:
     - 'docker build -t gusto-broken-record:$BUILDKITE_BUILD_ID .'
     - 'docker run -t gusto-broken-record:$BUILDKITE_BUILD_ID sh -c "gem build broken_record.gemspec && gem push --config-file .gem/credentials --key gemstash --host https://gemstash.zp-int.com/private *.gem"'
-    branches: 'master nw-ci-pipeline'
+    branches: master
     agents:
       queue: gemstash-publish

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,12 +5,12 @@ steps:
       - 'docker run -t gusto-broken-record:$BUILDKITE_BUILD_ID rspec'
 
   - block: ':rocket: Publish to Gem Server'
-    branches: master
+    branches: 'master nw-ci-pipeline'
 
   - name: ':rocket: Publish to Gem Server'
     command:
     - 'docker build -t gusto-broken-record:$BUILDKITE_BUILD_ID .'
     - 'docker run -t gusto-broken-record:$BUILDKITE_BUILD_ID sh -c "gem build broken_record.gemspec && gem push --config-file .gem/credentials --key gemstash --host https://gemstash.zp-int.com/private *.gem"'
-    branches: master
+    branches: 'master nw-ci-pipeline'
     agents:
       queue: gemstash-publish

--- a/broken_record.gemspec
+++ b/broken_record.gemspec
@@ -18,6 +18,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  if spec.respond_to?(:metadata)
+    spec.metadata['allowed_push_host'] = 'https://gemstash.zp-int.com/private'
+  else
+    raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
+  end
+
   spec.add_development_dependency 'bundler', '~> 2'
 
   spec.add_runtime_dependency 'rake', '>= 10.1.10'

--- a/lib/broken_record/version.rb
+++ b/lib/broken_record/version.rb
@@ -1,3 +1,3 @@
 module BrokenRecord
-  VERSION = '1.1.0.gusto'
+  VERSION = '1.1.0.test'
 end

--- a/lib/broken_record/version.rb
+++ b/lib/broken_record/version.rb
@@ -1,3 +1,3 @@
 module BrokenRecord
-  VERSION = '1.1.0.test'
+  VERSION = '1.1.0.gusto'
 end


### PR DESCRIPTION
# Overview
* Moved CI step from pipeline settings into `pipeline.yml`
* Also updated previous steps in CI (see below) to be compatible with BK agent v3 (since `BUILDKITE_DOCKER` is [deprecated](https://github.com/buildkite/agent/blob/master/bootstrap/docker.go#L40))
* Added CI step on `master` branch to push new gem after a `block` step i.e. engineer must unblock the step in BK UI in order to publish

## Previous pipeline steps 
```yml
steps:
  - name: ':rspec:'
    command: 'rspec'
    env:
      BUILDKITE_DOCKER: 'true'
```

## Test gem publish
https://buildkite.com/gusto/broken-record/builds/46
